### PR TITLE
Fix Blender 4.4 compatibility

### DIFF
--- a/bmesh_bend/__init__.py
+++ b/bmesh_bend/__init__.py
@@ -56,7 +56,7 @@ def sample_curve(curve_obj, resolution=64):
     """Sample points, tangents and orientation frames from the curve."""
     depsgraph = bpy.context.evaluated_depsgraph_get()
     eval_obj = curve_obj.evaluated_get(depsgraph)
-    curve = eval_obj.to_curve()
+    curve = eval_obj.to_curve(depsgraph)
 
     points = []
     tangents = []


### PR DESCRIPTION
## Summary
- fix required depsgraph argument to `Object.to_curve`

## Testing
- `python -m py_compile bmesh_bend/__init__.py`
- `flake8 bmesh_bend/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68403e3b39c0832aa5dcca61b7bfcc7f